### PR TITLE
Improve workflow handling and security

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -59,7 +59,7 @@ class Node(db.Model):
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(30))
-    password = db.Column(db.String(255))
+    password = db.Column(db.String(30))
 
     def __init__(self, name, password):
         self.name = name
@@ -88,3 +88,4 @@ class User(db.Model):
 
     def __repr__(self):
         return '<User:{}({})>'.format(self.name, self.id)
+

--- a/app/model.py
+++ b/app/model.py
@@ -3,7 +3,6 @@ import markdown
 from datetime import datetime
 
 db = SQLAlchemy()
-md = markdown.Markdown()
 
 workflows_tags = db.Table('workflows_tags',
                     db.Column('workflow_id', db.Integer, db.ForeignKey('workflow.id')),
@@ -35,7 +34,7 @@ class Workflow(db.Model):
         self.created_time = datetime.now()
         self.user_id = k["user_id"]
         self.content = k["content"]
-        self.rendered_content = md.convert(k["content"])
+        self.rendered_content = markdown.markdown(k["content"])
 
     def __repr__(self):
         return '<({}) {}>'.format(self.name, self.created_time)
@@ -60,7 +59,7 @@ class Node(db.Model):
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(30))
-    password = db.Column(db.String(30))
+    password = db.Column(db.String(255))
 
     def __init__(self, name, password):
         self.name = name


### PR DESCRIPTION
## Summary
- prevent duplicate and empty tags while ensuring workflow directories exist
- safely reopen uploaded workflow archives to extract metadata and render markdown without shared state
- expand the user password column for hashed credentials

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_6909b136591c8329a2f9feebb24dd84f